### PR TITLE
Use checked addition for `v5a` buffer flush

### DIFF
--- a/crates/fmtv5-types/src/v5/a/writer.rs
+++ b/crates/fmtv5-types/src/v5/a/writer.rs
@@ -343,7 +343,10 @@ impl CircuitWriterV5a {
         res?;
         self.io_buf = buf; // reuse allocation
         self.io_buf.clear(); // clear the buffer after reuse
-        self.next_offset += len as u64;
+        self.next_offset = self
+            .next_offset
+            .checked_add(len as u64)
+            .expect("file offset overflow");
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

Uses checked addition for computing the next offset during `v5a` buffer flushing. New tests were not added.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

This mirrors the approach used in `v5c`.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes #57.