### PR TITLE
Update and enforce output limit

### DIFF
--- a/crates/fmtv5-types/src/v5/c/SPEC.md
+++ b/crates/fmtv5-types/src/v5/c/SPEC.md
@@ -393,7 +393,7 @@ total_size = header_padded + outputs_padded + blocks_size
 5. **Reserved fields**: Must be zero
 6. **Gate counts**: `xor_gates + and_gates` must not overflow u64
 7. **Scratch space**: Must be ≤ 2³² (4,294,967,296)
-8. **Outputs**: `num_outputs` should be reasonable (< total_gates)
+8. **Outputs**: `num_outputs` must not exceed the sum of primary inputs and total gates
 
 ### Block Validation
 

--- a/crates/fmtv5-types/src/v5/c/header.rs
+++ b/crates/fmtv5-types/src/v5/c/header.rs
@@ -110,6 +110,11 @@ impl HeaderV5c {
             return Err("Total gate count would overflow".to_string());
         }
 
+        // Check number of outputs
+        if self.num_outputs > self.total_gates() + self.primary_inputs {
+            return Err("Too many outputs for gate and input count".to_string());
+        }
+
         // Validate scratch space
         if self.scratch_space > MAX_MEMORY_ADDRESS {
             return Err(format!(

--- a/crates/fmtv5-types/src/v5/c/integration.rs
+++ b/crates/fmtv5-types/src/v5/c/integration.rs
@@ -171,8 +171,8 @@ async fn test_large_outputs() {
 
     let mut writer = WriterV5c::new(path, 10, num_outputs as u64).await.unwrap();
 
-    // Write some gates
-    for i in 0..1000 {
+    // Write some gates (just enough to be valid for the output count)
+    for i in 0..99_990 {
         writer
             .write_gate(GateV5c::new(10, 11, 1000 + i), GateType::XOR)
             .await


### PR DESCRIPTION
## Description

Currently, the number of outputs must be strictly less than the number of gates. But as [noted](https://github.com/alpenlabs/ckt/issues/59#issuecomment-3698243525), this disallows certain cases where inputs are passed directly to outputs in small circuits (and likely other cases as well). This limit is only an initial reasonableness check, and is not even enforced during header parsing.

This PR changes the limit: now, the output count must not exceed the sum of the number of primary inputs and gates. The new limit is enforced during header parsing, and a failing test is updated accordingly.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

New tests are not added since the check is not critical, and since an existing test (correctly) failed against the new limit.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes #59.