### PR TITLE
(feat) input label translation refactored

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,8 +283,10 @@ version = "0.1.0"
 dependencies = [
  "aes",
  "bitvec",
+ "blake3",
  "criterion",
  "rand",
+ "rand_chacha",
 ]
 
 [[package]]

--- a/crates/gobble/Cargo.toml
+++ b/crates/gobble/Cargo.toml
@@ -8,6 +8,8 @@ repository.workspace = true
 
 [dependencies]
 bitvec.workspace = true
+blake3.workspace = true
+rand_chacha.workspace = true
 
 [dev-dependencies]
 aes.workspace = true
@@ -16,6 +18,10 @@ criterion.workspace = true
 
 [[bench]]
 name = "garbling"
+harness = false
+
+[[bench]]
+name = "translate"
 harness = false
 
 [lints]

--- a/crates/gobble/benches/translate.rs
+++ b/crates/gobble/benches/translate.rs
@@ -1,0 +1,90 @@
+//! Benchmarks for translation operations
+#![expect(missing_docs)]
+#![allow(unused_crate_dependencies)]
+
+use ckt_gobble::{BitLabel, ByteLabel, Label, generate_translation_material, translate, wide_hash};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+#[cfg(target_arch = "aarch64")]
+use ckt_gobble::aarch64::expand_seed;
+
+#[cfg(target_arch = "x86_64")]
+use ckt_gobble::x86_64::expand_seed;
+
+fn bench_wide_hash(c: &mut Criterion) {
+    c.bench_function("wide_hash", |b| {
+        let label = Label::from([0x42u8; 16]);
+        let index = 12345u64;
+
+        b.iter(|| {
+            let result = wide_hash(black_box(label), black_box(index));
+            black_box(result)
+        });
+    });
+}
+
+fn bench_generate_translation_material(c: &mut Criterion) {
+    c.bench_function("generate_translation_material", |b| {
+        // Setup: generate byte label and bit labels
+        let seed = [42u8; 32];
+        let (byte_labels, _) = expand_seed(seed, 256);
+        let byte_label = ByteLabel::new(byte_labels.try_into().unwrap());
+
+        let seed2 = [43u8; 32];
+        let (bit_labels_flat, _) = expand_seed(seed2, 16);
+        let default_label = Label::default();
+        let mut bit_labels = [BitLabel::new([default_label, default_label]); 8];
+        for i in 0..8 {
+            bit_labels[i] = BitLabel::new([bit_labels_flat[i * 2], bit_labels_flat[i * 2 + 1]]);
+        }
+
+        b.iter(|| {
+            let result = generate_translation_material(
+                black_box(0),
+                black_box(byte_label),
+                black_box(bit_labels),
+            );
+            black_box(result)
+        });
+    });
+}
+
+fn bench_translate(c: &mut Criterion) {
+    c.bench_function("translate", |b| {
+        // Setup: generate translation material
+        let seed = [42u8; 32];
+        let (byte_labels, _) = expand_seed(seed, 256);
+        let byte_label = ByteLabel::new(byte_labels.try_into().unwrap());
+
+        let seed2 = [43u8; 32];
+        let (bit_labels_flat, _) = expand_seed(seed2, 16);
+        let default_label = Label::default();
+        let mut bit_labels = [BitLabel::new([default_label, default_label]); 8];
+        for i in 0..8 {
+            bit_labels[i] = BitLabel::new([bit_labels_flat[i * 2], bit_labels_flat[i * 2 + 1]]);
+        }
+
+        let translation_material = generate_translation_material(0, byte_label, bit_labels);
+        let test_value = 42u8;
+        let byte_label_component = byte_label.get_label(test_value);
+
+        b.iter(|| {
+            let result = translate(
+                black_box(0),
+                black_box(byte_label_component),
+                black_box(test_value),
+                black_box(translation_material),
+            );
+            black_box(result)
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_wide_hash,
+    bench_generate_translation_material,
+    bench_translate
+);
+
+criterion_main!(benches);

--- a/crates/gobble/src/aarch64/mod.rs
+++ b/crates/gobble/src/aarch64/mod.rs
@@ -5,6 +5,9 @@
 use std::arch::aarch64::*;
 use std::mem::transmute;
 
+use rand_chacha::ChaCha20Rng;
+use rand_chacha::rand_core::{RngCore, SeedableRng};
+
 mod expand;
 
 use expand::expand_key;
@@ -14,6 +17,23 @@ pub type Aes128RoundKeys = expand::Aes128RoundKeys;
 
 // Re-export the unified types
 pub use crate::types::{Ciphertext, Label};
+
+/// Expand a seed into a vector of labels and a delta value.
+///
+/// This is useful for deterministic label generation in tests.
+pub fn expand_seed(seed: [u8; 32], num_inputs: u32) -> (Vec<Label>, Label) {
+    let mut rng = ChaCha20Rng::from_seed(seed);
+    let mut delta = [0u8; 16];
+    rng.fill_bytes(&mut delta);
+    let delta = Label(unsafe { transmute::<[u8; 16], uint8x16_t>(delta) });
+    let mut labels = Vec::with_capacity(num_inputs as usize);
+    for _ in 0..num_inputs {
+        let mut input = [0u8; 16];
+        rng.fill_bytes(&mut input);
+        labels.push(Label(unsafe { transmute::<[u8; 16], uint8x16_t>(input) }));
+    }
+    (labels, delta)
+}
 
 /// AES-128 key expansion using ARM AES instructions.
 ///

--- a/crates/gobble/src/lib.rs
+++ b/crates/gobble/src/lib.rs
@@ -1,6 +1,7 @@
 //! Core crate for garbling, executing and evaluating garbled/boolean circuits.
 
 pub mod traits;
+pub mod translate;
 pub mod types;
 
 // Architecture-specific intrinsics
@@ -19,6 +20,9 @@ pub mod garb;
 pub use eval::EvaluationInstanceImpl as EvaluationInstance;
 pub use exec::CleartextExecutionInstance as ExecutionInstance;
 pub use garb::GarblingInstanceImpl as GarblingInstance;
+pub use translate::{
+    BitLabel, ByteLabel, TranslationMaterial, generate_translation_material, translate, wide_hash,
+};
 pub use types::{Ciphertext, Label};
 
 use traits::{

--- a/crates/gobble/src/translate.rs
+++ b/crates/gobble/src/translate.rs
@@ -1,0 +1,306 @@
+//! Architecture-agnostic translation layer implementation
+//!
+//! This module provides translation between byte labels and bit labels,
+//! using Blake3 XOF for hash expansion.
+
+use crate::types::{Ciphertext, Label};
+
+/// XOR two 16-byte arrays.
+#[inline]
+fn xor_bytes(a: [u8; 16], b: [u8; 16]) -> [u8; 16] {
+    let mut result = [0u8; 16];
+    for i in 0..16 {
+        result[i] = a[i] ^ b[i];
+    }
+    result
+}
+
+/// Bit label type, representing value 0 or 1
+#[derive(Debug, Clone, Copy)]
+pub struct BitLabel([Label; 2]);
+
+impl BitLabel {
+    /// Creates a new BitLabel from an array of 2 labels
+    pub const fn new(labels: [Label; 2]) -> Self {
+        BitLabel(labels)
+    }
+
+    /// Returns the label for the given bit value
+    pub const fn get_label(&self, value: bool) -> Label {
+        if value { self.0[1] } else { self.0[0] }
+    }
+}
+
+/// Byte label type, representing value 0-255
+#[derive(Debug, Clone, Copy)]
+pub struct ByteLabel([Label; 256]);
+
+impl ByteLabel {
+    /// Creates a new ByteLabel from an array of 256 labels
+    pub const fn new(labels: [Label; 256]) -> Self {
+        ByteLabel(labels)
+    }
+
+    /// Returns the label for the given byte value
+    pub const fn get_label(&self, value: u8) -> Label {
+        self.0[value as usize]
+    }
+}
+
+/// Translation material: `[[Ciphertext; 8]; 256]`
+///
+/// - 256 possible byte values (0..255)
+/// - 8 ciphertexts per byte value (one per input bit position)
+/// - Size: 256 × 8 × 16 bytes = 32KB per byte position
+pub type TranslationMaterial = [[Ciphertext; 8]; 256];
+
+/// Expands hash to 8x width using Blake3 XOF (extendable output function).
+///
+/// The implementation uses Blake3's XOF to generate 128 bytes (8 labels * 16 bytes)
+/// with proper domain separation via the index parameter.
+///
+/// # Arguments
+///
+/// * `label` - Input label (128 bits)
+/// * `index` - Index value for domain separation
+///
+/// # Returns
+///
+/// Array of 8 labels, each 128 bits (16 bytes)
+pub fn wide_hash(label: Label, index: u64) -> [Label; 8] {
+    // Convert label to bytes
+    let label_bytes: [u8; 16] = label.into();
+
+    // Create input: label (16 bytes) + index (8 bytes, little-endian)
+    let mut input = [0u8; 24];
+    input[0..16].copy_from_slice(&label_bytes);
+    input[16..24].copy_from_slice(&index.to_le_bytes());
+
+    // Hash using Blake3 and get XOF output (128 bytes = 8 labels * 16 bytes)
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&input);
+    let mut output = [0u8; 128]; // 8 labels * 16 bytes
+    hasher.finalize_xof().fill(&mut output);
+
+    // Split into 8 labels
+    let mut labels = [Label::default(); 8];
+    for i in 0..8 {
+        let mut label_bytes = [0u8; 16];
+        label_bytes.copy_from_slice(&output[i * 16..(i + 1) * 16]);
+        labels[i] = Label::from(label_bytes);
+    }
+
+    labels
+}
+
+/// Generates garbled material required to translate ByteLabel component to BitLabel components.
+pub fn generate_translation_material(
+    byte_position: u64,
+    byte_label: ByteLabel,
+    bit_labels: [BitLabel; 8],
+) -> TranslationMaterial {
+    let mut ciphertexts = [[Ciphertext::default(); 8]; 256];
+
+    // For each possible byte value (0 to 255)
+    for (i, row) in ciphertexts.iter_mut().enumerate() {
+        // Get the label for this byte value
+        let input_label = byte_label.get_label(i as u8);
+
+        // Hash the input label to get 8 labels (one for each input bit position)
+        let hashed_labels = wide_hash(input_label, byte_position * 256 + i as u64);
+
+        // For each input bit position (within the byte)
+        for bit_position in 0..8 {
+            // Extract the bit at position bit_position from the byte value i
+            let bit_value = ((i >> bit_position) & 1) == 1;
+
+            // Get the appropriate bit label (0 or 1) based on the bit value of i
+            // This implements: C[i][j] = H_j(byte_label[i]) ⊕ bit_labels[j][bit_j_of_i]
+            let bit_label = bit_labels[bit_position].get_label(bit_value);
+
+            // XOR the hashed label with the bit label to create the ciphertext
+            let hashed_bytes: [u8; 16] = hashed_labels[bit_position].into();
+            let bit_label_bytes: [u8; 16] = bit_label.into();
+            row[bit_position] = Ciphertext::from(xor_bytes(hashed_bytes, bit_label_bytes));
+        }
+    }
+
+    ciphertexts
+}
+
+/// Translates a ByteLabel component to 8 BitLabel components using the translation material.
+///
+/// Given a label for a specific byte value, this function recovers the 8 bit labels
+/// corresponding to each bit of that byte value.
+pub fn translate(
+    byte_position: u64,
+    byte_label_component: Label,
+    value: u8,
+    translation_material: TranslationMaterial,
+) -> [Label; 8] {
+    // Hash the byte label component to get 8 hashed labels (one for each input bit position)
+    let hashed_labels = wide_hash(byte_label_component, byte_position * 256 + value as u64);
+
+    // Get the ciphertexts for this specific byte value
+    let ciphertexts = translation_material[value as usize];
+
+    // Decrypt each ciphertext to recover the input bit labels
+    // Since C[i][j] = H_j(byte_label[i]) ⊕ bit_label[j]
+    // We can recover: bit_label[j] = C[i][j] ⊕ H_j(byte_label[i])
+    let mut bit_labels = [Label::default(); 8];
+    for bit_position in 0..8 {
+        let ciphertext_bytes: [u8; 16] = ciphertexts[bit_position].into();
+        let hashed_bytes: [u8; 16] = hashed_labels[bit_position].into();
+        bit_labels[bit_position] = Label::from(xor_bytes(ciphertext_bytes, hashed_bytes));
+    }
+
+    bit_labels
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_arch = "aarch64")]
+    use crate::aarch64::expand_seed;
+
+    #[cfg(target_arch = "x86_64")]
+    use crate::x86_64::expand_seed;
+
+    #[test]
+    fn test_translation_roundtrip() {
+        // Generate random labels for a ByteLabel (256 labels, one for each byte value)
+        let seed = [42u8; 32];
+        let (byte_labels, _) = expand_seed(seed, 256);
+        let byte_label = ByteLabel::new(byte_labels.try_into().unwrap());
+
+        // Generate random labels for 8 BitLabels (each has 2 labels: for 0 and 1)
+        let seed2 = [43u8; 32];
+        let (bit_labels_flat, _) = expand_seed(seed2, 16); // 8 bits * 2 labels each
+        let default_label = Label::default();
+        let mut bit_labels = [BitLabel::new([default_label, default_label]); 8];
+        for i in 0..8 {
+            bit_labels[i] = BitLabel::new([bit_labels_flat[i * 2], bit_labels_flat[i * 2 + 1]]);
+        }
+
+        // Generate translation material
+        let translation_material = generate_translation_material(0, byte_label, bit_labels);
+
+        // Test translation for various byte values
+        for test_value in [0u8, 1, 7, 15, 42, 128, 255] {
+            // Get the byte label for this value
+            let byte_label_component = byte_label.get_label(test_value);
+
+            // Translate to get 8 bit labels
+            let recovered_labels =
+                translate(0, byte_label_component, test_value, translation_material);
+
+            // Verify each bit label matches the expected value
+            for bit_position in 0..8 {
+                // Extract the bit value at this position from test_value
+                let bit_value = ((test_value >> bit_position) & 1) == 1;
+
+                // Get the expected label for this bit value
+                let expected_label = bit_labels[bit_position].get_label(bit_value);
+
+                // Compare the recovered label with the expected label
+                let recovered_bytes: [u8; 16] = recovered_labels[bit_position].into();
+                let expected_bytes: [u8; 16] = expected_label.into();
+
+                assert_eq!(
+                    recovered_bytes, expected_bytes,
+                    "Mismatch for value {} at bit position {}: expected bit value {}",
+                    test_value, bit_position, bit_value
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_translation_all_values() {
+        // Test all 256 possible byte values
+        let seed = [99u8; 32];
+        let (byte_labels, _) = expand_seed(seed, 256);
+        let byte_label = ByteLabel::new(byte_labels.try_into().unwrap());
+
+        let seed2 = [100u8; 32];
+        let (bit_labels_flat, _) = expand_seed(seed2, 16);
+        let default_label = Label::default();
+        let mut bit_labels = [BitLabel::new([default_label, default_label]); 8];
+        for i in 0..8 {
+            bit_labels[i] = BitLabel::new([bit_labels_flat[i * 2], bit_labels_flat[i * 2 + 1]]);
+        }
+
+        let translation_material = generate_translation_material(0, byte_label, bit_labels);
+
+        // Test all 256 possible byte values
+        for test_value in 0u8..=255 {
+            let byte_label_component = byte_label.get_label(test_value);
+            let recovered_labels =
+                translate(0, byte_label_component, test_value, translation_material);
+
+            // Verify all 8 bits
+            for bit_position in 0..8 {
+                let bit_value = ((test_value >> bit_position) & 1) == 1;
+                let expected_label = bit_labels[bit_position].get_label(bit_value);
+
+                let recovered_bytes: [u8; 16] = recovered_labels[bit_position].into();
+                let expected_bytes: [u8; 16] = expected_label.into();
+
+                assert_eq!(
+                    recovered_bytes, expected_bytes,
+                    "Mismatch for value {} at bit position {}",
+                    test_value, bit_position
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_translation_bit_patterns() {
+        // Test specific bit patterns: all zeros, all ones, alternating patterns
+        let seed = [77u8; 32];
+        let (byte_labels, _) = expand_seed(seed, 256);
+        let byte_label = ByteLabel::new(byte_labels.try_into().unwrap());
+
+        let seed2 = [88u8; 32];
+        let (bit_labels_flat, _) = expand_seed(seed2, 16);
+        let default_label = Label::default();
+        let mut bit_labels = [BitLabel::new([default_label, default_label]); 8];
+        for i in 0..8 {
+            bit_labels[i] = BitLabel::new([bit_labels_flat[i * 2], bit_labels_flat[i * 2 + 1]]);
+        }
+
+        let translation_material = generate_translation_material(0, byte_label, bit_labels);
+
+        // Test specific patterns
+        let test_patterns = [
+            0b00000000, // All zeros
+            0b11111111, // All ones
+            0b10101010, // Alternating 1010...
+            0b01010101, // Alternating 0101...
+            0b11110000, // Half and half
+            0b00001111, // Other half
+        ];
+
+        for &test_value in &test_patterns {
+            let byte_label_component = byte_label.get_label(test_value);
+            let recovered_labels =
+                translate(0, byte_label_component, test_value, translation_material);
+
+            for bit_position in 0..8 {
+                let bit_value = ((test_value >> bit_position) & 1) == 1;
+                let expected_label = bit_labels[bit_position].get_label(bit_value);
+
+                let recovered_bytes: [u8; 16] = recovered_labels[bit_position].into();
+                let expected_bytes: [u8; 16] = expected_label.into();
+
+                assert_eq!(
+                    recovered_bytes, expected_bytes,
+                    "Mismatch for pattern {:08b} (value {}) at bit position {}",
+                    test_value, test_value, bit_position
+                );
+            }
+        }
+    }
+}

--- a/crates/gobble/src/x86_64/mod.rs
+++ b/crates/gobble/src/x86_64/mod.rs
@@ -5,6 +5,9 @@
 use std::arch::x86_64::*;
 use std::mem::transmute;
 
+use rand_chacha::ChaCha20Rng;
+use rand_chacha::rand_core::{RngCore, SeedableRng};
+
 mod expand;
 
 use expand::aes128 as expand_aes128;
@@ -14,6 +17,23 @@ pub type Aes128RoundKeys = expand::Aes128RoundKeys;
 
 // Re-export the unified types
 pub use crate::types::{Ciphertext, Label};
+
+/// Expand a seed into a vector of labels and a delta value.
+///
+/// This is useful for deterministic label generation in tests.
+pub fn expand_seed(seed: [u8; 32], num_inputs: u32) -> (Vec<Label>, Label) {
+    let mut rng = ChaCha20Rng::from_seed(seed);
+    let mut delta = [0u8; 16];
+    rng.fill_bytes(&mut delta);
+    let delta = Label(unsafe { transmute::<[u8; 16], __m128i>(delta) });
+    let mut labels = Vec::with_capacity(num_inputs as usize);
+    for _ in 0..num_inputs {
+        let mut input = [0u8; 16];
+        rng.fill_bytes(&mut input);
+        labels.push(Label(unsafe { transmute::<[u8; 16], __m128i>(input) }));
+    }
+    (labels, delta)
+}
 
 /// AES-128 key expansion using AES-NI instructions.
 ///

--- a/util/gobbletest/src/common.rs
+++ b/util/gobbletest/src/common.rs
@@ -1,9 +1,12 @@
 use bitvec::vec::BitVec;
 use ckt_fmtv5_types::v5::c::HeaderV5c;
+use ckt_gobble::{ByteLabel, Label, TranslationMaterial};
 use ckt_runner_types::{CircuitTask, GateBlock};
 use indicatif::{ProgressBar, ProgressStyle};
+use rand_chacha::ChaCha20Rng;
+use rand_chacha::rand_core::RngCore;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, BufWriter, Read, Write};
 use std::time::Instant;
 
 /// Read input bits from a text file containing 0s and 1s
@@ -34,6 +37,74 @@ pub fn read_inputs(input_file: &str, expected_num_inputs: usize) -> BitVec {
     }
 
     input_values_bits
+}
+
+/// Convert bits to bytes (LSB first within each byte)
+pub fn bits_to_bytes(bits: &BitVec, num_bytes: usize) -> Vec<u8> {
+    let mut bytes = vec![0u8; num_bytes];
+    for (i, bit) in bits.iter().enumerate() {
+        if *bit {
+            bytes[i / 8] |= 1 << (i % 8);
+        }
+    }
+    bytes
+}
+
+/// Generate random byte labels (256 labels per byte position)
+pub fn generate_byte_labels(num_bytes: usize, rng: &mut ChaCha20Rng) -> Vec<ByteLabel> {
+    let mut byte_labels = Vec::with_capacity(num_bytes);
+    for _ in 0..num_bytes {
+        let mut labels = [Label::default(); 256];
+        for label in &mut labels {
+            let mut bytes = [0u8; 16];
+            rng.fill_bytes(&mut bytes);
+            *label = Label::from(bytes);
+        }
+        byte_labels.push(ByteLabel::new(labels));
+    }
+    byte_labels
+}
+
+/// Write translation material to a file
+pub fn write_translation_material(path: &str, materials: &[TranslationMaterial]) {
+    let file = File::create(path).expect("Failed to create translation file");
+    let mut writer = BufWriter::new(file);
+
+    for material in materials {
+        for row in material {
+            for ct in row {
+                let bytes: [u8; 16] = (*ct).into();
+                writer
+                    .write_all(&bytes)
+                    .expect("Failed to write ciphertext");
+            }
+        }
+    }
+
+    writer.flush().expect("Failed to flush translation file");
+}
+
+/// Read translation material from a file
+pub fn read_translation_material(path: &str, num_bytes: usize) -> Vec<TranslationMaterial> {
+    let file = File::open(path).expect("Failed to open translation file");
+    let mut reader = BufReader::new(file);
+
+    let mut materials = Vec::with_capacity(num_bytes);
+    for _ in 0..num_bytes {
+        let mut material = [[ckt_gobble::Ciphertext::default(); 8]; 256];
+        for row in &mut material {
+            for ct in row {
+                let mut bytes = [0u8; 16];
+                reader
+                    .read_exact(&mut bytes)
+                    .expect("Failed to read ciphertext");
+                *ct = ckt_gobble::Ciphertext::from(bytes);
+            }
+        }
+        materials.push(material);
+    }
+
+    materials
 }
 
 /// Wrapper that adds progress bar reporting to a CircuitTask implementation.

--- a/util/gobbletest/src/e2e.rs
+++ b/util/gobbletest/src/e2e.rs
@@ -1,4 +1,4 @@
-use crate::{eval, exec, garble};
+use crate::{eval, eval_translate, exec, garble, garble_translate};
 use rand_chacha::ChaCha20Rng;
 
 pub async fn test_end_to_end(
@@ -88,4 +88,93 @@ fn xor_labels(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
         result[i] = a[i] ^ b[i];
     }
     result
+}
+
+pub async fn test_end_to_end_translate(
+    circuit_file: &str,
+    input_file: &str,
+    rng: &mut ChaCha20Rng,
+    garbled_file: Option<&str>,
+) {
+    let garbled_file = garbled_file.unwrap_or("gc.bin");
+
+    println!("🦃 Running end-to-end test with translation: exec → garble → eval\n");
+
+    // Step 1: Execute in cleartext to get expected outputs
+    println!("📊 Step 1: Executing circuit in cleartext...");
+    let cleartext_outputs = exec::exec(circuit_file, input_file).await;
+
+    // Step 2: Garble the circuit with translation
+    println!("\n🔒 Step 2: Garbling circuit with translation...");
+    let garble_output = garble_translate::garble_with_translation(
+        circuit_file,
+        input_file,
+        garbled_file,
+        rng,
+        None,
+    )
+    .await;
+
+    // Step 3: Evaluate the garbled circuit with translation
+    println!("\n🔓 Step 3: Evaluating garbled circuit with translation...");
+    let eval_output = eval_translate::eval_with_translation(
+        circuit_file,
+        garbled_file,
+        &garble_output.translation_file,
+        input_file,
+        &garble_output.selected_byte_labels,
+        garble_output.aes128_key,
+        garble_output.public_s,
+    )
+    .await;
+
+    // Step 4: Verify correctness
+    println!("\n✅ Step 4: Verifying correctness...");
+
+    let mut all_passed = true;
+
+    // Check that evaluator outputs match cleartext execution
+    if eval_output.output_values != cleartext_outputs {
+        println!("❌ FAILED: Evaluator outputs don't match cleartext execution!");
+        println!("   Expected: {:?}", cleartext_outputs);
+        println!("   Got:      {:?}", eval_output.output_values);
+        all_passed = false;
+    } else {
+        println!("✓ Evaluator outputs match cleartext execution");
+    }
+
+    // Check that output labels are consistent: garbler_label + value*delta = eval_label
+    for (i, (garbler_label, eval_label)) in garble_output
+        .garbler_output_labels
+        .iter()
+        .zip(eval_output.output_labels.iter())
+        .enumerate()
+    {
+        let value = eval_output.output_values[i];
+
+        // Compute expected eval label: garbler_label XOR (value ? delta : 0)
+        let expected_eval_label: [u8; 16] = if value {
+            xor_labels(garbler_label, &garble_output.delta)
+        } else {
+            *garbler_label
+        };
+
+        if &expected_eval_label != eval_label {
+            println!("❌ FAILED: Output label {} mismatch!", i);
+            println!("   Garbler label: {:?}", garbler_label);
+            println!("   Delta:         {:?}", garble_output.delta);
+            println!("   Value:         {}", value);
+            println!("   Expected eval: {:?}", expected_eval_label);
+            println!("   Got eval:      {:?}", eval_label);
+            all_passed = false;
+        }
+    }
+
+    if all_passed {
+        println!("✓ All output labels are consistent");
+        println!("\n🎉 All tests passed!");
+    } else {
+        println!("\n❌ Some tests failed!");
+        std::process::exit(1);
+    }
 }

--- a/util/gobbletest/src/eval_translate.rs
+++ b/util/gobbletest/src/eval_translate.rs
@@ -1,0 +1,123 @@
+use std::fs::File;
+use std::io::BufReader;
+
+use bitvec::vec::BitVec;
+use ckt_fmtv5_types::v5::c::ReaderV5c;
+use ckt_gobble::{Label, traits::EvaluationInstanceConfig, translate};
+use ckt_runner_exec::{CircuitReader, EvalTask, ReaderV5cWrapper, process_task};
+
+use crate::common::{ProgressBarTask, bits_to_bytes, read_inputs, read_translation_material};
+
+/// Output from evaluation with translation support.
+#[derive(Debug)]
+pub struct EvalTranslationOutput {
+    /// Output labels from evaluation.
+    pub output_labels: Vec<[u8; 16]>,
+    /// Output boolean values corresponding to the labels.
+    pub output_values: Vec<bool>,
+}
+
+/// Evaluation with translation support.
+///
+/// Translates byte labels to bit labels using translation material, then runs standard evaluation.
+pub async fn eval_with_translation(
+    circuit_file: &str,
+    ciphertext_file: &str,
+    translation_file: &str,
+    input_file: &str,
+    byte_labels: &[[u8; 16]],
+    aes128_key: [u8; 16],
+    public_s: [u8; 16],
+) -> EvalTranslationOutput {
+    let mut reader = ReaderV5cWrapper::new(ReaderV5c::open(circuit_file).unwrap());
+    let header = *reader.header();
+
+    // Read inputs as bits and convert to bytes (need to know byte values for translation)
+    let num_bits = header.primary_inputs as usize;
+    let num_bytes = num_bits.div_ceil(8);
+    let input_bits = read_inputs(input_file, num_bits);
+    let input_bytes = bits_to_bytes(&input_bits, num_bytes);
+
+    assert_eq!(
+        byte_labels.len(),
+        num_bytes,
+        "Expected {} byte labels, got {}",
+        num_bytes,
+        byte_labels.len()
+    );
+
+    // Read translation material from file
+    let translation_material = read_translation_material(translation_file, num_bytes);
+
+    // Translate byte labels to bit labels
+    // Only translate exactly primary_inputs bits (may be less than num_bytes * 8)
+    let mut bit_labels = Vec::new();
+    let mut input_values_bits = BitVec::new();
+    let mut bit_count = 0;
+
+    for byte_position in 0..num_bytes {
+        let byte_label = Label::from(byte_labels[byte_position]);
+        let byte_value = input_bytes[byte_position];
+
+        // Translate: byte_label to 8 bit labels
+        let translated_bit_labels = translate(
+            byte_position as u64,
+            byte_label,
+            byte_value,
+            translation_material[byte_position],
+        );
+
+        // Extract bit values and labels
+        for (bit_position, translated_label) in translated_bit_labels.iter().enumerate() {
+            if bit_count >= header.primary_inputs as usize {
+                break;
+            }
+            let bit_value = ((byte_value >> bit_position) & 1) == 1;
+            input_values_bits.push(bit_value);
+
+            let label_bytes: [u8; 16] = (*translated_label).into();
+            bit_labels.push(label_bytes);
+            bit_count += 1;
+        }
+        if bit_count >= header.primary_inputs as usize {
+            break;
+        }
+    }
+
+    assert_eq!(
+        bit_labels.len(),
+        header.primary_inputs as usize,
+        "Expected {} bit labels, got {}",
+        header.primary_inputs,
+        bit_labels.len()
+    );
+
+    // Run standard evaluation
+    let config = EvaluationInstanceConfig {
+        scratch_space: header.scratch_space as u32,
+        selected_primary_input_labels: &bit_labels,
+        selected_primary_input_values: &input_values_bits,
+        aes128_key,
+        public_s,
+    };
+
+    let task_info = EvalTask::new(config);
+    let task_with_progress = ProgressBarTask::new(task_info);
+
+    // Open the ciphertext reader.
+    let garbled_file = File::open(ciphertext_file).unwrap();
+    let ct_reader = BufReader::new(garbled_file);
+
+    // Execute the evaluation loop.
+    let output = process_task(&task_with_progress, ct_reader, &mut reader)
+        .await
+        .expect("eval: process task");
+
+    println!("Output labels: {:?}", output.output_labels);
+    println!("Output values: {:?}", output.output_values);
+
+    EvalTranslationOutput {
+        output_labels: output.output_labels,
+        output_values: output.output_values,
+    }
+}

--- a/util/gobbletest/src/garble_translate.rs
+++ b/util/gobbletest/src/garble_translate.rs
@@ -1,0 +1,187 @@
+use std::fs::File;
+use std::io::BufWriter;
+
+use ckt_fmtv5_types::v5::c::*;
+use ckt_gobble::{
+    BitLabel, ByteLabel, Label, generate_translation_material, traits::GarblingInstanceConfig,
+};
+use ckt_runner_exec::{CircuitReader, GarbleTask, ReaderV5cWrapper, process_task};
+use rand_chacha::ChaCha20Rng;
+use rand_chacha::rand_core::RngCore;
+
+use crate::common::{
+    ProgressBarTask, bits_to_bytes, generate_byte_labels, read_inputs, write_translation_material,
+};
+
+/// Output from garbling with translation support.
+#[derive(Debug)]
+pub struct GarbleTranslationOutput {
+    /// Global delta used for FreeXOR optimization.
+    pub delta: [u8; 16],
+    /// Selected byte labels corresponding to the input byte values.
+    pub selected_byte_labels: Vec<[u8; 16]>,
+    /// Path to the translation material file.
+    pub translation_file: String,
+    /// Output labels from the garbler.
+    pub garbler_output_labels: Vec<[u8; 16]>,
+    /// AES-128 key used for garbling.
+    pub aes128_key: [u8; 16],
+    /// Public S value used in CCRND hash.
+    pub public_s: [u8; 16],
+}
+
+/// Garbling with translation support.
+pub async fn garble_with_translation(
+    circuit_file: &str,
+    input_file: &str,
+    output_file: &str,
+    rng: &mut ChaCha20Rng,
+    byte_labels: Option<Vec<ByteLabel>>,
+) -> GarbleTranslationOutput {
+    let mut reader = ReaderV5cWrapper::new(ReaderV5c::open(circuit_file).unwrap());
+    let header = *reader.header();
+
+    // Read inputs as bits and convert to bytes
+    let num_bits = header.primary_inputs as usize;
+    let num_bytes = num_bits.div_ceil(8);
+    let input_bits = read_inputs(input_file, num_bits);
+    let input_bytes = bits_to_bytes(&input_bits, num_bytes);
+
+    // Generate or use provided byte labels
+    let byte_labels_vec = byte_labels.unwrap_or_else(|| generate_byte_labels(num_bytes, rng));
+
+    assert_eq!(
+        byte_labels_vec.len(),
+        num_bytes,
+        "Expected {} byte labels, got {}",
+        num_bytes,
+        byte_labels_vec.len()
+    );
+
+    // Generate global delta (same as used in standard garbling)
+    // This delta ensures FreeXOR optimization: true_label = false_label XOR delta
+    let mut delta_bytes = [0u8; 16];
+    rng.fill_bytes(&mut delta_bytes);
+    let delta = Label::from(delta_bytes);
+
+    // Import xor128 function
+    #[cfg(target_arch = "aarch64")]
+    use ckt_gobble::aarch64::xor128;
+    #[cfg(target_arch = "x86_64")]
+    use ckt_gobble::x86_64::xor128;
+
+    // Generate bit labels for each byte position
+    let mut bit_labels_vec = Vec::new(); // Vec<[BitLabel; 8]>
+
+    for _byte_position in 0..num_bytes {
+        // Generate 8 false labels (one per bit position)
+        // True labels will be computed as false_label XOR delta (FreeXOR optimization)
+        let default_label = Label::from([0u8; 16]);
+        let mut bit_labels_array = [BitLabel::new([default_label, default_label]); 8];
+
+        for bit_label in &mut bit_labels_array {
+            // Generate false label (for bit value 0)
+            let mut false_label_bytes = [0u8; 16];
+            rng.fill_bytes(&mut false_label_bytes);
+            let false_label = Label::from(false_label_bytes);
+
+            // Compute true label (for bit value 1) = false_label XOR delta
+            // This ensures global delta correlation for FreeXOR optimization
+            let true_label = Label(unsafe { xor128(false_label.0, delta.0) });
+
+            *bit_label = BitLabel::new([false_label, true_label]);
+        }
+        bit_labels_vec.push(bit_labels_array);
+    }
+
+    // Generate translation material
+    let mut translation_material = Vec::new();
+    for byte_position in 0..num_bytes {
+        let material = generate_translation_material(
+            byte_position as u64,
+            byte_labels_vec[byte_position],
+            bit_labels_vec[byte_position],
+        );
+        translation_material.push(material);
+    }
+
+    // Write translation material to file
+    let translation_file = format!("{}.translation", output_file);
+    write_translation_material(&translation_file, &translation_material);
+    println!("✓ Translation material written to {}", translation_file);
+
+    // Flatten bit labels for garbling
+    // Convert [byte_position][bit_position] -> flat Vec<[u8; 16]>
+    // This becomes primary_input_false_labels for standard garbling
+    // These labels already have delta correlation (true = false XOR delta)
+    // This ensures FreeXOR optimization works correctly
+    // Note: Only generate exactly primary_inputs bits (may be less than num_bytes * 8)
+    let mut primary_input_false_labels = Vec::new();
+    let mut bit_count = 0;
+    'outer: for bit_labels_array in &bit_labels_vec {
+        for bit_label in bit_labels_array {
+            if bit_count >= header.primary_inputs as usize {
+                break 'outer;
+            }
+            // Get false label (index 0) from BitLabel
+            let false_label = bit_label.get_label(false);
+            let label_bytes: [u8; 16] = false_label.into();
+            primary_input_false_labels.push(label_bytes);
+            bit_count += 1;
+        }
+    }
+
+    assert_eq!(
+        primary_input_false_labels.len(),
+        header.primary_inputs as usize,
+        "Expected {} primary input labels, got {}",
+        header.primary_inputs,
+        primary_input_false_labels.len()
+    );
+
+    // Generate AES key and public S for this garbling instance
+    let mut aes128_key = [0u8; 16];
+    rng.fill_bytes(&mut aes128_key);
+    let mut public_s = [0u8; 16];
+    rng.fill_bytes(&mut public_s);
+
+    // Run standard garbling
+    let config = GarblingInstanceConfig {
+        scratch_space: header.scratch_space as u32,
+        delta: delta_bytes, // Same delta used for bit label generation
+        primary_input_false_labels: &primary_input_false_labels,
+        aes128_key,
+        public_s,
+    };
+
+    let task_info = GarbleTask::new(config);
+    let task_with_progress = ProgressBarTask::new(task_info);
+
+    // Open the output writer.
+    let file = File::create(output_file).unwrap();
+    let writer = BufWriter::new(file);
+
+    // Execute the garbling loop.
+    let output = process_task(&task_with_progress, writer, &mut reader)
+        .await
+        .expect("garble: process task");
+
+    println!("\n✓ Garbled circuit written to {}", output_file);
+
+    // Select byte labels based on input bytes
+    let mut selected_byte_labels = Vec::new();
+    for byte_position in 0..num_bytes {
+        let byte_value = input_bytes[byte_position];
+        let label = byte_labels_vec[byte_position].get_label(byte_value);
+        selected_byte_labels.push(label.into());
+    }
+
+    GarbleTranslationOutput {
+        delta: delta_bytes,
+        selected_byte_labels,
+        translation_file,
+        garbler_output_labels: output.garbler_output_labels,
+        aes128_key,
+        public_s,
+    }
+}

--- a/util/gobbletest/src/main.rs
+++ b/util/gobbletest/src/main.rs
@@ -1,8 +1,10 @@
 mod common;
 mod e2e;
 mod eval;
+mod eval_translate;
 mod exec;
 mod garble;
+mod garble_translate;
 
 use rand_chacha::ChaCha20Rng;
 use rand_chacha::rand_core::SeedableRng;
@@ -17,6 +19,9 @@ async fn main() {
         eprintln!("  garble <circuit>                              - Run garble test");
         eprintln!(
             "  e2e <circuit> <inputs> [garbled_circuit_path] - Run end-to-end test: exec → garble → eval"
+        );
+        eprintln!(
+            "  e2e-translate <circuit> <inputs> [garbled_circuit_path] - Run e2e test with byte-to-bit translation"
         );
         std::process::exit(1);
     }
@@ -47,9 +52,22 @@ async fn main() {
             let garbled_path = args.get(4).map(|s| s.as_str());
             e2e::test_end_to_end(circuit, inputs, &mut rng, garbled_path).await;
         }
+        "e2e-translate" => {
+            if args.len() != 4 && args.len() != 5 {
+                eprintln!(
+                    "Usage: {} e2e-translate <circuit> <inputs> [garbled_circuit_path]",
+                    args[0]
+                );
+                std::process::exit(1);
+            }
+            let circuit = &args[2];
+            let inputs = &args[3];
+            let garbled_path = args.get(4).map(|s| s.as_str());
+            e2e::test_end_to_end_translate(circuit, inputs, &mut rng, garbled_path).await;
+        }
         _ => {
             eprintln!("Unknown mode: {}", mode);
-            eprintln!("Valid modes: garble, e2e");
+            eprintln!("Valid modes: garble, e2e, e2e-translate");
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
## Description

Initial implementation of label translation utility: A garbler can provide 1 input ByteLabel and 8 output BitLabels and generate the required translation material for an evaluator to translate 1 Label (1 of 256 in ByteLabel) to the appropriate set of 8 Labels (1 of 2 for each of the 8 BitLabels). Along with the translation utility, this PR also adds an e2e test in `gobbletest/`. 

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

This PR is still in draft mode because (1) the wide hash function used is currently instantiated using Fixed Key AES with different tweaks for each output block but the tweak should be derived from some equivalent of "gate id", and the security of a particular instantiation should be studied carefully and (2) the e2e test is currently buggy, I'm working on a fix. 

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

This replaces a previous PR (#30) and addresses #20.
