### PR TITLE
fix: expose gobbletest exec as lib

### DIFF
--- a/util/gobbletest/src/lib.rs
+++ b/util/gobbletest/src/lib.rs
@@ -1,0 +1,5 @@
+//! Cleartext-exec entry point exposed for use as a library dependency.
+
+#[allow(dead_code)]
+mod common;
+pub mod exec;


### PR DESCRIPTION
## Description

This PR exposes the gobble test exec as a public API for downstream binaries to execute the circuit generated by using this library. The rationale is that after generation of circuit, test runs can be performed for sanity checks.


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
