### PR TITLE
fix: used checked subtraction for gate region

### DIFF
--- a/crates/fmtv5-types/src/v5/c/reader.rs
+++ b/crates/fmtv5-types/src/v5/c/reader.rs
@@ -82,7 +82,15 @@ impl ReaderV5c {
         let outputs_padded_size = padded_size(outputs_bytes_len);
         let gate_region_start = ALIGNMENT as u64 + outputs_padded_size as u64;
         let gate_region_end = file_size;
-        let gate_region_bytes = gate_region_end - gate_region_start;
+        let gate_region_bytes =
+            gate_region_end
+                .checked_sub(gate_region_start)
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::InvalidData,
+                        "file truncated before outputs boundary",
+                    )
+                })?;
 
         // Validate that gate region is multiple of BLOCK_SIZE
         if !gate_region_bytes.is_multiple_of(BLOCK_SIZE as u64) {


### PR DESCRIPTION
## Description

Computation of the gate region in the `v5c` reader uses unchecked subtraction, which can underflow.

This PR replaces it with checked subtraction.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

N/A

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes #102.