### PR TITLE
feat!: add arbitrary memo to circuit headers

### DIFF
--- a/crates/fmtv5-types/src/v5/SPEC.md
+++ b/crates/fmtv5-types/src/v5/SPEC.md
@@ -40,12 +40,12 @@ The format offers two variants optimized for different stages of the circuit pip
 The BLAKE3 checksum is computed over the concatenation of:
 1. **GATE BLOCKS** section (all blocks for v5a)
 2. **OUTPUTS** section (entire section as written)
-3. **HEADER** fields after the checksum field (bytes 40 onward: metadata fields)
+3. **HEADER** fields other than the checksum
 
 **Note**: This order differs from the physical file layout (Header → Outputs → Gate Blocks). The modified order enables streaming hash computation during write operations: blocks can be hashed as they're written to disk, then outputs and header metadata are hashed at finalization. This eliminates the need for a second pass over potentially billions of gates.
 
 **Physical file order**: Header → Outputs → Gate Blocks
-**Checksum order**: Gate Blocks → Outputs → Header tail
+**Checksum order**: Gate Blocks → Outputs → Header
 
 This design allows writers to compute checksums in a single streaming pass without seeking.
 
@@ -234,8 +234,9 @@ for block in blocks {
 // 2. Hash outputs section
 hasher.update(&outputs_data);
 
-// 3. Hash header fields after checksum (bytes 72..104 for v5a)
-hasher.update(&header_bytes[72..]);  // Skip magic, version, type, reserved, checksum
+// 3. Hash header fields other than checksum
+hasher.update(&header_bytes[0..40]);
+hasher.update(&header_bytes[72..104]);
 
 let computed = hasher.finalize();
 assert_eq!(computed.as_bytes(), &header.checksum);

--- a/crates/fmtv5-types/src/v5/SPEC.md
+++ b/crates/fmtv5-types/src/v5/SPEC.md
@@ -54,15 +54,16 @@ This design allows writers to compute checksums in a single streaming pass witho
 ### Purpose
 v5a is an intermediate format that preserves wire IDs and credits for memory management. It bridges source formats and the production v5c format, maintaining the credits system for compile-time garbage collection.
 
-### Header Structure (72 bytes)
+### Header Structure (104 bytes)
 
 ```c
 struct HeaderV5a {
-    // Identification (8 bytes)
+    // Identification (40 bytes)
     magic: [u8; 4],          // 4 bytes: "Zk2u" (0x5A6B3275)
     version: u8,             // 1 byte: Always 0x05
     format_type: u8,         // 1 byte: Always 0x00 for v5a
     reserved: [u8; 2],       // 2 bytes: Reserved, must be 0x0000
+    memo: [u8; 32],          // 32 bytes: Arbitrary memo data
 
     // Checksum (32 bytes)
     checksum: [u8; 32],      // 32 bytes: BLAKE3 hash
@@ -233,8 +234,8 @@ for block in blocks {
 // 2. Hash outputs section
 hasher.update(&outputs_data);
 
-// 3. Hash header fields after checksum (bytes 40..72 for v5a)
-hasher.update(&header_bytes[40..]);  // Skip magic, version, type, reserved, checksum
+// 3. Hash header fields after checksum (bytes 72..104 for v5a)
+hasher.update(&header_bytes[72..]);  // Skip magic, version, type, reserved, checksum
 
 let computed = hasher.finalize();
 assert_eq!(computed.as_bytes(), &header.checksum);

--- a/crates/fmtv5-types/src/v5/a/integration.rs
+++ b/crates/fmtv5-types/src/v5/a/integration.rs
@@ -25,9 +25,10 @@ async fn write_file(
     path: &std::path::Path,
     primary_inputs: u64,
     outputs: Vec<u64>,
+    memo: [u8; 32],
     gates: &[GateV5a],
 ) {
-    let mut w = CircuitWriterV5a::new(path, primary_inputs, outputs)
+    let mut w = CircuitWriterV5a::new(path, primary_inputs, outputs, memo)
         .await
         .unwrap();
     w.write_gates(gates).await.unwrap();
@@ -38,13 +39,15 @@ async fn write_file(
 async fn round_trip_small() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("rt_small.v5a");
+    let memo = [1u8; 32];
 
     let outputs = vec![2, 3, 4, 5, 6];
     let gates: Vec<_> = (0..123u64).map(mk_gate).collect();
-    write_file(&path, 42, outputs.clone(), &gates).await;
+    write_file(&path, 42, outputs.clone(), memo, &gates).await;
 
     let mut r = CircuitReaderV5a::open(&path).unwrap();
     assert_eq!(r.header().primary_inputs, 42);
+    assert_eq!(r.header().memo, memo);
     assert_eq!(r.outputs(), &outputs[..]);
 
     // Accumulate all gates back
@@ -79,7 +82,7 @@ async fn round_trip_cross_triplebuffer_chunk_boundary() {
     let outputs = vec![9, 10, 11];
     let gates: Vec<_> = (0..total_gates).map(mk_gate).collect();
 
-    write_file(&path, 7, outputs.clone(), &gates).await;
+    write_file(&path, 7, outputs.clone(), [0u8; 32], &gates).await;
 
     let mut r = CircuitReaderV5a::open(&path).unwrap();
     assert_eq!(r.outputs(), &outputs[..]);

--- a/crates/fmtv5-types/src/v5/a/mod.rs
+++ b/crates/fmtv5-types/src/v5/a/mod.rs
@@ -31,7 +31,7 @@ pub const CREDITS_OUTPUT: u32 = 0; // Wire is a circuit output
 pub const CREDITS_CONSTANT: u32 = MAX_CREDITS; // Wire is constant/primary input
 
 // v5a header constants (fixed by spec)
-pub const HEADER_SIZE_V5A: usize = 72;
+pub const HEADER_SIZE_V5A: usize = 104;
 pub const MAGIC: [u8; 4] = *b"Zk2u";
 pub const VERSION: u8 = 0x05;
 pub const FORMAT_TYPE_A: u8 = 0x00;
@@ -61,6 +61,7 @@ pub struct HeaderV5a {
     pub version: u8,         // 0x05
     pub format_type: u8,     // 0x00 for v5a
     pub reserved: [u8; 2],   // 0x0000
+    pub memo: [u8; 32],      // arbitrary memo data
     pub checksum: [u8; 32],  // blake3
     pub xor_gates: u64,      // LE
     pub and_gates: u64,      // LE
@@ -96,19 +97,23 @@ fn parse_header(bytes: &[u8; HEADER_SIZE_V5A]) -> io::Result<HeaderV5a> {
         ));
     }
 
-    let mut checksum = [0u8; 32];
-    checksum.copy_from_slice(&bytes[8..40]);
+    let mut memo = [0u8; 32];
+    memo.copy_from_slice(&bytes[8..40]);
 
-    let xor_gates = u64::from_le_bytes(bytes[40..48].try_into().unwrap());
-    let and_gates = u64::from_le_bytes(bytes[48..56].try_into().unwrap());
-    let primary_inputs = u64::from_le_bytes(bytes[56..64].try_into().unwrap());
-    let num_outputs = u64::from_le_bytes(bytes[64..72].try_into().unwrap());
+    let mut checksum = [0u8; 32];
+    checksum.copy_from_slice(&bytes[40..72]);
+
+    let xor_gates = u64::from_le_bytes(bytes[72..80].try_into().unwrap());
+    let and_gates = u64::from_le_bytes(bytes[80..88].try_into().unwrap());
+    let primary_inputs = u64::from_le_bytes(bytes[88..96].try_into().unwrap());
+    let num_outputs = u64::from_le_bytes(bytes[96..104].try_into().unwrap());
 
     Ok(HeaderV5a {
         magic: MAGIC,
         version: bytes[4],
         format_type: bytes[5],
         reserved: [0, 0],
+        memo,
         checksum,
         xor_gates,
         and_gates,

--- a/crates/fmtv5-types/src/v5/a/reader.rs
+++ b/crates/fmtv5-types/src/v5/a/reader.rs
@@ -520,7 +520,6 @@ pub async fn verify_v5a_checksum(path: impl AsRef<Path>) -> Result<bool> {
         hasher.update(&outs);
     }
 
-
     // 3. Header (without checksum)
     hasher.update(&header[0..40]);
     hasher.update(&header[72..104]);

--- a/crates/fmtv5-types/src/v5/a/reader.rs
+++ b/crates/fmtv5-types/src/v5/a/reader.rs
@@ -482,7 +482,7 @@ pub async fn verify_v5a_checksum(path: impl AsRef<Path>) -> Result<bool> {
         .try_into()
         .map_err(|_| Error::new(ErrorKind::InvalidData, "header size mismatch"))?;
     let hdr = parse_header(&header)?;
-    let file_checksum = &header[8..40];
+    let file_checksum = &header[40..72];
     let outputs_len = (hdr.num_outputs as usize) * 5;
 
     let mut hasher = Hasher::new();
@@ -521,7 +521,7 @@ pub async fn verify_v5a_checksum(path: impl AsRef<Path>) -> Result<bool> {
     }
 
     // 3. Header tail
-    hasher.update(&header[40..72]);
+    hasher.update(&header[72..104]);
 
     Ok(hasher.finalize().as_bytes() == file_checksum)
 }
@@ -549,8 +549,14 @@ mod tests {
         }
     }
 
-    async fn write_file(path: &Path, primary_inputs: u64, outputs: Vec<u64>, gates: &[GateV5a]) {
-        let mut w = CircuitWriterV5a::new(path, primary_inputs, outputs)
+    async fn write_file(
+        path: &Path,
+        primary_inputs: u64,
+        outputs: Vec<u64>,
+        memo: [u8; 32],
+        gates: &[GateV5a],
+    ) {
+        let mut w = CircuitWriterV5a::new(path, primary_inputs, outputs, memo)
             .await
             .unwrap();
         w.write_gates(gates).await.unwrap();
@@ -561,10 +567,11 @@ mod tests {
     async fn reader_open_header_outputs_and_no_blocks() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("empty.v5a");
+        let memo = [1u8; 32];
 
         let primary_inputs = 12;
         let outputs = vec![2, 3, 4, 5];
-        write_file(&path, primary_inputs, outputs.clone(), &[]).await;
+        write_file(&path, primary_inputs, outputs.clone(), memo, &[]).await;
 
         let mut r = CircuitReaderV5a::open(&path).unwrap();
         let h = r.header();
@@ -573,6 +580,7 @@ mod tests {
         assert_eq!(h.format_type, 0x00);
         assert_eq!(h.primary_inputs, primary_inputs);
         assert_eq!(h.num_outputs, outputs.len() as u64);
+        assert_eq!(h.memo, memo);
         assert_eq!(r.outputs(), &outputs[..]);
 
         // No blocks
@@ -587,7 +595,7 @@ mod tests {
         let path = dir.path().join("partial.v5a");
 
         let gates: Vec<_> = (0..3u64).map(mk_gate).collect();
-        write_file(&path, 7, vec![6, 7], &gates).await;
+        write_file(&path, 7, vec![6, 7], [0u8; 32], &gates).await;
 
         let mut r = CircuitReaderV5a::open(&path).unwrap();
 
@@ -619,7 +627,7 @@ mod tests {
 
         // 256 + 10 = 266 gates
         let gates: Vec<_> = (0..(GATES_PER_BLOCK as u64 + 10)).map(mk_gate).collect();
-        write_file(&path, 0, vec![1], &gates).await;
+        write_file(&path, 0, vec![1], [0u8; 32], &gates).await;
 
         let mut r = CircuitReaderV5a::open(&path).unwrap();
 
@@ -663,7 +671,7 @@ mod tests {
         let path = dir.path().join("aos_soa.v5a");
 
         let gates: Vec<_> = (0..20u64).map(mk_gate).collect();
-        write_file(&path, 1, vec![3, 9], &gates).await;
+        write_file(&path, 1, vec![3, 9], [0u8; 32], &gates).await;
 
         // Use two independent readers so we compare the SAME block without borrow conflicts.
         let mut r_soa = CircuitReaderV5a::open(&path).unwrap();
@@ -707,7 +715,7 @@ mod tests {
 
         // Use 1 output (5 bytes) -> HEADER 72 + outputs 5 => start_off=77, misaligned.
         let gates: Vec<_> = (0..17u64).map(mk_gate).collect();
-        write_file(&path, 0, vec![42], &gates).await;
+        write_file(&path, 0, vec![42], [0u8; 32], &gates).await;
 
         let mut r = CircuitReaderV5a::open(&path).unwrap();
 
@@ -739,7 +747,7 @@ mod tests {
         let path = dir.path().join("verify.v5a");
 
         let gates: Vec<_> = (0..5u64).map(mk_gate).collect();
-        write_file(&path, 9, vec![7, 8], &gates).await;
+        write_file(&path, 9, vec![7, 8], [0u8; 32], &gates).await;
 
         // Verify via standalone async function (no streaming reader needed).
         assert!(verify_v5a_checksum(&path).await.unwrap());

--- a/crates/fmtv5-types/src/v5/a/reader.rs
+++ b/crates/fmtv5-types/src/v5/a/reader.rs
@@ -487,7 +487,7 @@ pub async fn verify_v5a_checksum(path: impl AsRef<Path>) -> Result<bool> {
 
     let mut hasher = Hasher::new();
 
-    // Checksum order: blocks || outputs || header tail
+    // Checksum order: blocks || outputs || header
 
     // 1. Blocks region
     let total_gates = hdr.total_gates();
@@ -520,7 +520,9 @@ pub async fn verify_v5a_checksum(path: impl AsRef<Path>) -> Result<bool> {
         hasher.update(&outs);
     }
 
-    // 3. Header tail
+
+    // 3. Header (without checksum)
+    hasher.update(&header[0..40]);
     hasher.update(&header[72..104]);
 
     Ok(hasher.finalize().as_bytes() == file_checksum)

--- a/crates/fmtv5-types/src/v5/a/writer.rs
+++ b/crates/fmtv5-types/src/v5/a/writer.rs
@@ -277,14 +277,16 @@ impl CircuitWriterV5a {
         let outputs_bytes = encode_outputs_le34(&self.outputs)?;
         self.hasher.update(&outputs_bytes);
 
-        // Hash header fields after checksum
-        // Order: xor_gates, and_gates, primary_inputs, num_outputs (all LE)
-        let mut header_tail = [0u8; 32];
-        header_tail[0..8].copy_from_slice(&self.xor_gates_written.to_le_bytes());
-        header_tail[8..16].copy_from_slice(&self.and_gates_written.to_le_bytes());
-        header_tail[16..24].copy_from_slice(&self.primary_inputs.to_le_bytes());
-        header_tail[24..32].copy_from_slice(&(self.outputs.len() as u64).to_le_bytes());
-        self.hasher.update(&header_tail);
+        // Hash header fields other than checksum in order
+        self.hasher.update(&MAGIC);
+        self.hasher.update(&[VERSION]);
+        self.hasher.update(&[FORMAT_TYPE_A]);
+        self.hasher.update(&[0, 0]);
+        self.hasher.update(&self.memo);
+        self.hasher.update(&self.xor_gates_written.to_le_bytes());
+        self.hasher.update(&self.and_gates_written.to_le_bytes());
+        self.hasher.update(&self.primary_inputs.to_le_bytes());
+        self.hasher.update(&(self.outputs.len() as u64).to_le_bytes());
 
         let checksum = *self.hasher.finalize().as_bytes();
 
@@ -710,7 +712,7 @@ mod tests {
 
         let mut hasher = Hasher::new();
 
-        // Checksum order: blocks || outputs || header tail
+        // Checksum order: blocks || outputs || header
 
         // 1. Hash blocks (seek past outputs to blocks region)
         f.seek(SeekFrom::Start((HEADER_SIZE_V5A + outputs_size) as u64))?;
@@ -726,7 +728,8 @@ mod tests {
             hasher.update(&outputs);
         }
 
-        // 3. Hash header tail
+        // 3. Hash header without checksum
+        hasher.update(&header[0..40]);
         hasher.update(&header[72..104]);
 
         Ok(hasher.finalize().as_bytes() == file_checksum)

--- a/crates/fmtv5-types/src/v5/a/writer.rs
+++ b/crates/fmtv5-types/src/v5/a/writer.rs
@@ -152,6 +152,7 @@ pub struct CircuitWriterV5a {
     // Metadata
     primary_inputs: u64,
     outputs: Vec<u64>, // original outputs (for validation), we also store serialized bytes
+    memo: [u8; 32],
 
     // Offsets and aggregation
     next_offset: u64, // where the next write after outputs will go
@@ -175,6 +176,7 @@ impl CircuitWriterV5a {
         path: impl AsRef<Path>,
         primary_inputs: u64,
         outputs: Vec<u64>,
+        memo: [u8; 32],
     ) -> Result<Self> {
         // Validate outputs and encode to bytes (5 bytes per output, lower 34 bits)
         let outputs_bytes = encode_outputs_le34(&outputs)?;
@@ -184,7 +186,7 @@ impl CircuitWriterV5a {
         opts.create(true).write(true).truncate(true);
         let file = opts.open(path.as_ref()).await?;
 
-        // Write header placeholder (72 bytes of zero) and outputs
+        // Write header placeholder (104 bytes of zero) and outputs
         let header_placeholder = vec![0u8; HEADER_SIZE_V5A];
         let outputs_offset = HEADER_SIZE_V5A as u64;
         {
@@ -208,6 +210,7 @@ impl CircuitWriterV5a {
             file,
             primary_inputs,
             outputs,
+            memo,
             next_offset,
             io_buf: Vec::with_capacity(DEFAULT_IO_BUFFER_CAP),
             io_buf_cap: DEFAULT_IO_BUFFER_CAP,
@@ -292,6 +295,7 @@ impl CircuitWriterV5a {
             self.and_gates_written,
             self.primary_inputs,
             self.outputs.len() as u64,
+            self.memo,
         );
 
         // Write header back at offset 0
@@ -352,13 +356,14 @@ impl CircuitWriterV5a {
     }
 }
 
-/// Encode v5a header to bytes (72 bytes total, LE).
+/// Encode v5a header to bytes (104 bytes total, LE).
 fn encode_header_v5a_le(
     checksum: &[u8; 32],
     xor_gates: u64,
     and_gates: u64,
     primary_inputs: u64,
     num_outputs: u64,
+    memo: [u8; 32],
 ) -> [u8; HEADER_SIZE_V5A] {
     let mut h = [0u8; HEADER_SIZE_V5A];
     // Identification
@@ -366,13 +371,14 @@ fn encode_header_v5a_le(
     h[4] = VERSION;
     h[5] = FORMAT_TYPE_A;
     // h[6..8] reserved zeros
+    h[8..40].copy_from_slice(&memo);
     // Checksum
-    h[8..40].copy_from_slice(checksum);
+    h[40..72].copy_from_slice(checksum);
     // Metadata (LE)
-    h[40..48].copy_from_slice(&xor_gates.to_le_bytes());
-    h[48..56].copy_from_slice(&and_gates.to_le_bytes());
-    h[56..64].copy_from_slice(&primary_inputs.to_le_bytes());
-    h[64..72].copy_from_slice(&num_outputs.to_le_bytes());
+    h[72..80].copy_from_slice(&xor_gates.to_le_bytes());
+    h[80..88].copy_from_slice(&and_gates.to_le_bytes());
+    h[88..96].copy_from_slice(&primary_inputs.to_le_bytes());
+    h[96..104].copy_from_slice(&num_outputs.to_le_bytes());
     h
 }
 
@@ -564,7 +570,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("empty.v5a");
 
-        let writer = CircuitWriterV5a::new(&path, 10, vec![2, 3, 4])
+        let writer = CircuitWriterV5a::new(&path, 10, vec![2, 3, 4], [0u8; 32])
             .await
             .unwrap();
         let stats = writer.finalize().await.unwrap();
@@ -582,7 +588,9 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("gates.v5a");
 
-        let mut writer = CircuitWriterV5a::new(&path, 2, vec![6]).await.unwrap();
+        let mut writer = CircuitWriterV5a::new(&path, 2, vec![6], [0u8; 32])
+            .await
+            .unwrap();
 
         let gates = vec![
             GateV5a {
@@ -621,7 +629,7 @@ mod tests {
         let mut f = StdOpen::new().read(true).open(&path).unwrap();
         let mut header = [0u8; HEADER_SIZE_V5A];
         f.read_exact(&mut header).unwrap();
-        let num_outputs = u64::from_le_bytes(header[64..72].try_into().unwrap()) as usize;
+        let num_outputs = u64::from_le_bytes(header[96..104].try_into().unwrap()) as usize;
         let outputs_size = num_outputs * 5;
         f.seek(SeekFrom::Start((HEADER_SIZE_V5A + outputs_size) as u64))
             .unwrap();
@@ -643,7 +651,7 @@ mod tests {
         let path = dir.path().join("bad_out.v5a");
         let too_big = MAX_WIRE_ID + 1;
 
-        let res = CircuitWriterV5a::new(&path, 2, vec![too_big]).await;
+        let res = CircuitWriterV5a::new(&path, 2, vec![too_big], [0u8; 32]).await;
         assert!(res.is_err());
     }
 
@@ -653,7 +661,7 @@ mod tests {
         let path = dir.path().join("corrupt.v5a");
 
         {
-            let mut writer = CircuitWriterV5a::new(&path, 3, vec![100, 101])
+            let mut writer = CircuitWriterV5a::new(&path, 3, vec![100, 101], [0u8; 32])
                 .await
                 .unwrap();
             let gates = vec![
@@ -680,7 +688,7 @@ mod tests {
 
         // Corrupt a byte in the blocks area
         let mut f = StdOpen::new().read(true).write(true).open(&path).unwrap();
-        f.seek(SeekFrom::Start(100)).unwrap();
+        f.seek(SeekFrom::Start(132)).unwrap();
         f.write_all(&[0xFF]).unwrap();
 
         assert!(!verify_file_checksum(&path).unwrap());
@@ -696,8 +704,8 @@ mod tests {
         if &header[0..4] != b"Zk2u" || header[4] != 0x05 || header[5] != 0x00 {
             return Err(Error::new(ErrorKind::InvalidData, "invalid header"));
         }
-        let file_checksum = &header[8..40];
-        let num_outputs = u64::from_le_bytes(header[64..72].try_into().unwrap()) as usize;
+        let file_checksum = &header[40..72];
+        let num_outputs = u64::from_le_bytes(header[96..104].try_into().unwrap()) as usize;
         let outputs_size = num_outputs * 5;
 
         let mut hasher = Hasher::new();
@@ -719,7 +727,7 @@ mod tests {
         }
 
         // 3. Hash header tail
-        hasher.update(&header[40..72]);
+        hasher.update(&header[72..104]);
 
         Ok(hasher.finalize().as_bytes() == file_checksum)
     }

--- a/crates/fmtv5-types/src/v5/a/writer.rs
+++ b/crates/fmtv5-types/src/v5/a/writer.rs
@@ -286,7 +286,8 @@ impl CircuitWriterV5a {
         self.hasher.update(&self.xor_gates_written.to_le_bytes());
         self.hasher.update(&self.and_gates_written.to_le_bytes());
         self.hasher.update(&self.primary_inputs.to_le_bytes());
-        self.hasher.update(&(self.outputs.len() as u64).to_le_bytes());
+        self.hasher
+            .update(&(self.outputs.len() as u64).to_le_bytes());
 
         let checksum = *self.hasher.finalize().as_bytes();
 

--- a/crates/fmtv5-types/src/v5/c/SPEC.md
+++ b/crates/fmtv5-types/src/v5/c/SPEC.md
@@ -35,7 +35,7 @@ Block working set:
 ## File Structure
 
 ```
-[HEADER]          88 bytes → padded to next 256 KiB boundary
+[HEADER]          120 bytes → padded to next 256 KiB boundary
 [OUTPUTS]         num_outputs × 4 bytes → padded to next 256 KiB boundary
 [GATE BLOCKS]     Sequence of 256 KiB blocks:
   Block 0:        256 KiB
@@ -64,11 +64,11 @@ All major sections are aligned to 256 KiB boundaries for optimal mmap and io_uri
 #define BLOCK_PADDING        1         // To reach 262,144 bytes
 
 // Header/output sizes
-#define HEADER_SIZE          88
+#define HEADER_SIZE          120
 #define OUTPUT_ENTRY_SIZE    4
 ```
 
-## Header Structure (88 bytes)
+## Header Structure (120 bytes)
 
 ```c
 struct HeaderV5c {
@@ -77,6 +77,7 @@ struct HeaderV5c {
     version: u8,             // 1 byte: Always 0x05
     format_type: u8,         // 1 byte: Always 0x02 for v5c
     nkas: [u8; 4],           // 4 bytes: "nkas" (0x6E6B6173)
+    memo: [u8; 32],          // 32 bytes: arbitrary memo data
 
     // Checksum (32 bytes)
     checksum: [u8; 32],      // 32 bytes: BLAKE3 hash
@@ -89,7 +90,7 @@ struct HeaderV5c {
     num_outputs: u64,        // 8 bytes: Number of outputs
     reserved2: [u8; 6],      // 6 bytes: Reserved for future use
 }
-// Total: 88 bytes
+// Total: 120 bytes
 // Padded to: 262,144 bytes (256 KiB)
 ```
 
@@ -99,6 +100,7 @@ struct HeaderV5c {
 - **version**: Must be `0x05`
 - **format_type**: Must be `0x02` (identifies v5c variant)
 - **nkas**: Must be `[0x6E, 0x6B, 0x61, 0x73]` ("nkas")
+- **memo**: Arbitrary
 - **checksum**: BLAKE3 hash (see Checksum Calculation)
 - **xor_gates**: Total count of XOR gates in circuit
 - **and_gates**: Total count of AND gates in circuit
@@ -233,7 +235,7 @@ The BLAKE3 checksum is computed over **the entire file** except the checksum fie
 **Hash order** (to enable streaming during writes):
 1. **GATE BLOCKS** section - all full 256 KiB blocks including 1-byte padding within each
 2. **OUTPUTS** section - with padding to 256 KiB boundary
-3. **HEADER** section - bytes 0-8, skip bytes 8-40 (checksum field), bytes 40-88, then padding to 256 KiB
+3. **HEADER** section - all bytes except checksum, then padding to 256 KiB
 
 This differs from the physical file layout (Header → Outputs → Gate Blocks) to enable streaming hash computation during writes.
 
@@ -252,10 +254,10 @@ let outputs_padded_size = padded_size(num_outputs * 4);
 hasher.update(&outputs_padded_data);  // Includes padding to 256 KiB boundary
 
 // 3. Hash header (skip only the checksum field itself)
-hasher.update(&header_bytes[0..10]);     // magic, version, format_type, nkas
-// Skip bytes 10-42: checksum field
-hasher.update(&header_bytes[42..88]);    // all circuit metadata
-let header_padding = vec![0u8; 256*1024 - 88];
+hasher.update(&header_bytes[0..42]);     // magic, version, format_type, nkas, memo
+// Skip 32-byte checksum
+hasher.update(&header_bytes[42..74]);    // all circuit metadata
+let header_padding = vec![0u8; 256*1024 - 74];
 hasher.update(&header_padding);          // padding to 256 KiB
 
 let computed = hasher.finalize();
@@ -265,7 +267,7 @@ assert_eq!(computed.as_bytes(), &header.checksum);
 **What is included in checksum:**
 - All gate blocks: full 256 KiB each (gates + types + 1-byte padding)
 - Outputs section: data + padding to 256 KiB boundary
-- Header section: all bytes except checksum field (10-42) + padding to 256 KiB
+- Header section: all bytes except checksum + padding to 256 KiB
 - **Summary: Everything in the file except the checksum field itself**
 
 ## File Layout Example
@@ -275,7 +277,7 @@ assert_eq!(computed.as_bytes(), &header.checksum);
 ```
 Section         Unpadded Size   Padded Size     Content
 ────────────────────────────────────────────────────────────────
-Header          88 bytes        256 KiB         HeaderV5c + padding
+Header          120 bytes       256 KiB         HeaderV5c + padding
 Outputs         4,000 bytes     256 KiB         [u32; 1000] + padding
 Block 0         262,144 bytes   256 KiB         21,620 gates (full)
 Block 1         262,144 bytes   256 KiB         21,620 gates (full)
@@ -289,14 +291,14 @@ Total           ~786 KB         1.25 MB
 ```
 Section         Unpadded Size   Padded Size     Overhead
 ────────────────────────────────────────────────────────────────
-Header          88 bytes        256 KiB         ~256 KiB
+Header          120 bytes       256 KiB         ~256 KiB
 Outputs         4,000 bytes     256 KiB         ~256 KiB
 Blocks          ~145.5 GB       ~145.5 GB       < 256 KiB
 ────────────────────────────────────────────────────────────────
 Total           ~145.5 GB       ~145.5 GB       ~512 KiB
 
 Number of blocks: ⌈12,000,000,000 / 21,620⌉ = 555,041 blocks
-File size: 88 bytes + 256 KiB + 4,000 bytes + 256 KiB + (555,041 × 256 KiB)
+File size: 256 KiB + 4,000 bytes + 256 KiB + (555,041 × 256 KiB)
          ≈ 145.5 GB
 
 Overhead: 0.00034% (negligible for large circuits)
@@ -407,7 +409,7 @@ total_size = header_padded + outputs_padded + blocks_size
 
 1. Read all gate blocks (including padding)
 2. Read outputs (including padding)
-3. Read header tail (bytes 40..88)
+3. Read header tail
 4. Compute BLAKE3 hash in the specified order
 5. Compare with header checksum field
 
@@ -429,7 +431,7 @@ impl ReaderV5c {
         let mmap = unsafe { MmapOptions::new().map(&file)? };
         
         // Parse header
-        let header = HeaderV5c::from_bytes(&mmap[0..88])?;
+        let header = HeaderV5c::from_bytes(&mmap[0..120])?;
         header.validate()?;
         
         Ok(ReaderV5c { header, mmap })
@@ -586,7 +588,7 @@ impl WriterV5c {
         
         // Write header (padded to 256 KiB)
         let mut header_padded = vec![0u8; 262144];
-        header_padded[..88].copy_from_slice(&self.header.to_bytes());
+        header_padded[..120].copy_from_slice(&self.header.to_bytes());
         self.file.write_all(&header_padded)?;
         
         // Write outputs (padded to 256 KiB)
@@ -600,7 +602,7 @@ impl WriterV5c {
         
         // Complete checksum: hash outputs then header tail
         self.hasher.update(&outputs_padded[..outputs_size]); // No padding
-        self.hasher.update(&self.header.to_bytes()[40..88]);
+        self.hasher.update(&self.header.to_bytes()[74..120]);
         
         let checksum = self.hasher.finalize();
         self.header.checksum.copy_from_slice(checksum.as_bytes());

--- a/crates/fmtv5-types/src/v5/c/SPEC.md
+++ b/crates/fmtv5-types/src/v5/c/SPEC.md
@@ -256,8 +256,8 @@ hasher.update(&outputs_padded_data);  // Includes padding to 256 KiB boundary
 // 3. Hash header (skip only the checksum field itself)
 hasher.update(&header_bytes[0..42]);     // magic, version, format_type, nkas, memo
 // Skip 32-byte checksum
-hasher.update(&header_bytes[42..74]);    // all circuit metadata
-let header_padding = vec![0u8; 256*1024 - 74];
+hasher.update(&header_bytes[74..120]);    // all circuit metadata
+let header_padding = vec![0u8; 256*1024 - 120];
 hasher.update(&header_padding);          // padding to 256 KiB
 
 let computed = hasher.finalize();

--- a/crates/fmtv5-types/src/v5/c/constants.rs
+++ b/crates/fmtv5-types/src/v5/c/constants.rs
@@ -15,7 +15,7 @@ pub const BLOCK_PADDING: usize = BLOCK_SIZE - GATES_SIZE - TYPES_SIZE; // 1 byte
 pub const GATE_SIZE: usize = 12;
 
 /// Header size
-pub const HEADER_SIZE: usize = 88;
+pub const HEADER_SIZE: usize = 120;
 
 /// Output entry size (u32 LE)
 pub const OUTPUT_ENTRY_SIZE: usize = 4;

--- a/crates/fmtv5-types/src/v5/c/header.rs
+++ b/crates/fmtv5-types/src/v5/c/header.rs
@@ -2,16 +2,17 @@ use std::io::{self, Error, ErrorKind};
 
 use super::constants::*;
 
-/// Header structure for v5c format (88 bytes)
+/// Header structure for v5c format (120 bytes)
 ///
 /// The header is padded to 256 KiB in the file for alignment.
 #[derive(Debug, Clone, Copy)]
 pub struct HeaderV5c {
-    // Identification (10 bytes)
+    // Identification (42 bytes)
     pub magic: [u8; 4],  // "Zk2u" (0x5A6B3275)
     pub version: u8,     // Always 0x05
     pub format_type: u8, // Always 0x02 for v5c
     pub nkas: [u8; 4],   // "nkas" (0x6E6B6173)
+    pub memo: [u8; 32],  // Arbitrary memo data
 
     // Checksum (32 bytes)
     pub checksum: [u8; 32], // BLAKE3 hash
@@ -33,6 +34,7 @@ impl HeaderV5c {
             version: VERSION,
             format_type: FORMAT_TYPE,
             nkas: NKAS,
+            memo: [0; 32],
             checksum: [0; 32],
             xor_gates: 0,
             and_gates: 0,
@@ -149,6 +151,10 @@ impl HeaderV5c {
         bytes[offset..offset + 4].copy_from_slice(&self.nkas);
         offset += 4;
 
+        // memo (32 bytes)
+        bytes[offset..offset + 32].copy_from_slice(&self.memo);
+        offset += 32;
+
         // checksum (32 bytes)
         bytes[offset..offset + 32].copy_from_slice(&self.checksum);
         offset += 32;
@@ -207,6 +213,11 @@ impl HeaderV5c {
         let mut nkas = [0u8; 4];
         nkas.copy_from_slice(&bytes[offset..offset + 4]);
         offset += 4;
+
+        // memo (32 bytes)
+        let mut memo = [0u8; 32];
+        memo.copy_from_slice(&bytes[offset..offset + 32]);
+        offset += 32;
 
         // checksum (32 bytes)
         let mut checksum = [0u8; 32];
@@ -287,6 +298,7 @@ impl HeaderV5c {
             version,
             format_type,
             nkas,
+            memo,
             checksum,
             xor_gates,
             and_gates,

--- a/crates/fmtv5-types/src/v5/c/integration.rs
+++ b/crates/fmtv5-types/src/v5/c/integration.rs
@@ -10,9 +10,10 @@ use crate::v5::c::*;
 #[monoio::test]
 async fn test_round_trip_small_circuit() {
     let path = "/tmp/test_v5c_round_trip_small.ckt";
+    let memo = [1u8; 32];
 
     // Write a small circuit (4 gates)
-    let mut writer = WriterV5c::new(path, 2, 1).await.unwrap();
+    let mut writer = WriterV5c::new(path, 2, 1, memo).await.unwrap();
     writer
         .write_gate(GateV5c::new(2, 3, 4), GateType::XOR)
         .await
@@ -38,6 +39,7 @@ async fn test_round_trip_small_circuit() {
     // Read back
     let mut reader = ReaderV5c::open(path).unwrap();
     assert_eq!(reader.header().total_gates(), 4);
+    assert_eq!(reader.header().memo, memo);
     assert_eq!(reader.outputs(), &[7]);
 
     // Get blocks (should be first buffer with 1 partial block)
@@ -78,10 +80,11 @@ async fn test_round_trip_small_circuit() {
 #[monoio::test]
 async fn test_round_trip_multiple_blocks() {
     let path = "/tmp/test_v5c_round_trip_multi.ckt";
+    let memo = [1u8; 32];
 
     // Write enough gates for 2 full blocks + partial
     let total_gates = GATES_PER_BLOCK * 2 + 1000;
-    let mut writer = WriterV5c::new(path, 100, 10).await.unwrap();
+    let mut writer = WriterV5c::new(path, 100, 10, memo).await.unwrap();
 
     for i in 0..total_gates {
         let gate = GateV5c::new(100, 101, 102 + i as u32);
@@ -105,6 +108,7 @@ async fn test_round_trip_multiple_blocks() {
     // Read back
     let mut reader = ReaderV5c::open(path).unwrap();
     assert_eq!(reader.header().total_gates(), total_gates as u64);
+    assert_eq!(reader.header().memo, memo);
     assert_eq!(reader.outputs(), &outputs[..]);
 
     // 2 full blocks + 1 partial = 3 blocks
@@ -130,7 +134,7 @@ async fn test_arc_sharing_pattern() {
     let path = "/tmp/test_v5c_arc_sharing.ckt";
 
     // Write a circuit with exactly GATES_PER_BLOCK gates (1 full block)
-    let mut writer = WriterV5c::new(path, 10, 1).await.unwrap();
+    let mut writer = WriterV5c::new(path, 10, 1, [0u8; 32]).await.unwrap();
 
     for i in 0..GATES_PER_BLOCK {
         let gate = GateV5c::new(10, 11, 100 + i as u32);
@@ -164,12 +168,15 @@ async fn test_arc_sharing_pattern() {
 #[monoio::test]
 async fn test_large_outputs() {
     let path = "/tmp/test_v5c_large_outputs.ckt";
+    let memo = [1u8; 32];
 
     // Create circuit with >256 KiB of outputs (requires multiple 256 KiB sections)
     let num_outputs = 100_000; // 400 KB of outputs
     let outputs: Vec<u32> = (1000..1000 + num_outputs).collect();
 
-    let mut writer = WriterV5c::new(path, 10, num_outputs as u64).await.unwrap();
+    let mut writer = WriterV5c::new(path, 10, num_outputs as u64, memo)
+        .await
+        .unwrap();
 
     // Write some gates (just enough to be valid for the output count)
     for i in 0..99_990 {
@@ -183,6 +190,7 @@ async fn test_large_outputs() {
 
     // Read back and verify outputs
     let reader = ReaderV5c::open(path).unwrap();
+    assert_eq!(reader.header().memo, memo);
     assert_eq!(reader.outputs().len(), num_outputs as usize);
     assert_eq!(reader.outputs(), &outputs[..]);
 
@@ -194,7 +202,7 @@ async fn test_checksum_verification() {
     let path = "/tmp/test_v5c_checksum.ckt";
 
     // Write a circuit
-    let mut writer = WriterV5c::new(path, 5, 2).await.unwrap();
+    let mut writer = WriterV5c::new(path, 5, 2, [0u8; 32]).await.unwrap();
 
     for i in 0..100 {
         writer
@@ -230,7 +238,7 @@ async fn test_partial_last_block() {
 
     // Write exactly 1.5 blocks worth of gates
     let total_gates = GATES_PER_BLOCK + (GATES_PER_BLOCK / 2);
-    let mut writer = WriterV5c::new(path, 10, 1).await.unwrap();
+    let mut writer = WriterV5c::new(path, 10, 1, [0u8; 32]).await.unwrap();
 
     for i in 0..total_gates {
         writer
@@ -267,7 +275,7 @@ async fn test_partial_last_block() {
 async fn test_empty_circuit_rejected() {
     let path = "/tmp/test_v5c_empty.ckt";
 
-    let writer = WriterV5c::new(path, 0, 0).await.unwrap();
+    let writer = WriterV5c::new(path, 0, 0, [0u8; 32]).await.unwrap();
 
     // Try to finalize without writing any gates
     let result = writer.finalize(100, vec![]).await;
@@ -284,7 +292,7 @@ async fn test_empty_circuit_rejected() {
 async fn test_writer_validates_addresses() {
     let path = "/tmp/test_v5c_validate_addr.ckt";
 
-    let mut writer = WriterV5c::new(path, 10, 1).await.unwrap();
+    let mut writer = WriterV5c::new(path, 10, 1, [0u8; 32]).await.unwrap();
 
     // Write valid gate
     writer

--- a/crates/fmtv5-types/src/v5/c/reader.rs
+++ b/crates/fmtv5-types/src/v5/c/reader.rs
@@ -38,7 +38,7 @@ impl ReaderV5c {
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let mut f = std::fs::OpenOptions::new().read(true).open(path.as_ref())?;
 
-        // Read and parse header (88 bytes)
+        // Read and parse header (120 bytes)
         let mut hdr_bytes = [0u8; HEADER_SIZE];
         f.read_exact(&mut hdr_bytes)?;
         let header = HeaderV5c::from_bytes(&hdr_bytes)?;
@@ -320,7 +320,7 @@ pub async fn verify_v5c_checksum(path: impl AsRef<Path>) -> Result<bool> {
     hdr.validate()
         .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
 
-    let file_checksum = &header_arr[10..42];
+    let file_checksum = &header_arr[42..74];
 
     let outputs_len = (hdr.num_outputs as usize)
         .checked_mul(4)
@@ -370,11 +370,11 @@ pub async fn verify_v5c_checksum(path: impl AsRef<Path>) -> Result<bool> {
         hasher.update(&outputs_padded);
     }
 
-    // 3. Hash header: before checksum (0-10) + after checksum (42-88) + padding to 256 KiB
-    hasher.update(&header_arr[0..10]); // magic, version, format_type, nkas
-    // Skip checksum field (bytes 10-42)
-    hasher.update(&header_arr[42..HEADER_SIZE]); // all metadata fields
-    // Hash header padding (88 bytes to 256 KiB)
+    // 3. Hash header: before checksum (0-42) + after checksum (74-120) + padding to 256 KiB
+    hasher.update(&header_arr[0..42]); // magic, version, format_type, nkas, memo
+    // Skip checksum field (bytes 42-74)
+    hasher.update(&header_arr[74..HEADER_SIZE]); // all metadata fields
+    // Hash header padding (120 bytes to 256 KiB)
     let header_padding = vec![0u8; ALIGNMENT - HEADER_SIZE];
     hasher.update(&header_padding);
 

--- a/crates/fmtv5-types/src/v5/c/writer.rs
+++ b/crates/fmtv5-types/src/v5/c/writer.rs
@@ -33,6 +33,7 @@ pub struct WriterV5c {
     // Metadata
     primary_inputs: u64,
     num_outputs: u64,
+    memo: [u8; 32],
 
     // File offsets
     outputs_offset: u64, // Start of outputs section
@@ -61,13 +62,14 @@ impl WriterV5c {
         path: impl AsRef<Path>,
         primary_inputs: u64,
         num_outputs: u64,
+        memo: [u8; 32],
     ) -> Result<Self> {
         // Open/truncate file
         let mut opts = OpenOptions::new();
         opts.create(true).write(true).truncate(true);
         let file = opts.open(path.as_ref()).await?;
 
-        // Write header placeholder (88 bytes) padded to 256 KiB
+        // Write header placeholder (120 bytes) padded to 256 KiB
         let header_padded_size = ALIGNMENT;
         let header_placeholder = vec![0u8; header_padded_size];
         {
@@ -95,6 +97,7 @@ impl WriterV5c {
             file,
             primary_inputs,
             num_outputs,
+            memo,
             outputs_offset,
             next_offset: blocks_start_offset,
             block_buffer: Box::new([0u8; BLOCK_SIZE]),
@@ -246,6 +249,7 @@ impl WriterV5c {
         // Hash header: before checksum + after checksum + all padding to 256 KiB
         // Build complete header first
         let mut temp_header = HeaderV5c::new();
+        temp_header.memo = self.memo;
         temp_header.xor_gates = self.xor_gates_written;
         temp_header.and_gates = self.and_gates_written;
         temp_header.primary_inputs = self.primary_inputs;
@@ -255,12 +259,12 @@ impl WriterV5c {
 
         let temp_header_bytes = temp_header.to_bytes();
 
-        // Hash header before checksum field (bytes 0-10: magic, version, format_type, nkas)
-        self.hasher.update(&temp_header_bytes[0..10]);
-        // Skip checksum field (bytes 10-42)
-        // Hash header after checksum field (bytes 42-88: all metadata)
-        self.hasher.update(&temp_header_bytes[42..88]);
-        // Hash header padding (88 bytes to 256 KiB)
+        // Hash header before checksum field (bytes 0-42: magic, version, format_type, nkas, memo)
+        self.hasher.update(&temp_header_bytes[0..42]);
+        // Skip checksum field (bytes 42-74)
+        // Hash header after checksum field (bytes 74-10: all metadata)
+        self.hasher.update(&temp_header_bytes[74..120]);
+        // Hash header padding (120 bytes to 256 KiB)
         let header_padding = vec![0u8; ALIGNMENT - HEADER_SIZE];
         self.hasher.update(&header_padding);
 
@@ -269,6 +273,7 @@ impl WriterV5c {
 
         // Build complete header
         let mut header = HeaderV5c::new();
+        header.memo = self.memo;
         header.xor_gates = self.xor_gates_written;
         header.and_gates = self.and_gates_written;
         header.primary_inputs = self.primary_inputs;
@@ -276,7 +281,7 @@ impl WriterV5c {
         header.num_outputs = self.num_outputs;
         header.checksum = checksum;
 
-        // Write header at offset 0 (only 88 bytes, not padding)
+        // Write header at offset 0 (only 120 bytes, not padding)
         let header_bytes = header.to_bytes();
         {
             let (res, _) = self.file.write_all_at(header_bytes.to_vec(), 0).await;
@@ -356,7 +361,7 @@ mod tests {
         let path = "/tmp/test_v5c_write_simple.ckt";
 
         // Create writer
-        let mut writer = WriterV5c::new(path, 2, 1).await?;
+        let mut writer = WriterV5c::new(path, 2, 1, [0u8; 32]).await?;
 
         // Write 4 gates in execution order
         writer
@@ -404,7 +409,7 @@ mod tests {
     async fn test_writer_validates_scratch_space() {
         let path = "/tmp/test_v5c_scratch_space.ckt";
 
-        let mut writer = WriterV5c::new(path, 2, 1).await.unwrap();
+        let mut writer = WriterV5c::new(path, 2, 1, [0u8; 32]).await.unwrap();
         writer
             .write_gate(GateV5c::new(2, 3, 100), GateType::XOR)
             .await

--- a/crates/fmtv5-types/src/v5/c/writer.rs
+++ b/crates/fmtv5-types/src/v5/c/writer.rs
@@ -262,7 +262,7 @@ impl WriterV5c {
         // Hash header before checksum field (bytes 0-42: magic, version, format_type, nkas, memo)
         self.hasher.update(&temp_header_bytes[0..42]);
         // Skip checksum field (bytes 42-74)
-        // Hash header after checksum field (bytes 74-10: all metadata)
+        // Hash header after checksum field (bytes 74-104: all metadata)
         self.hasher.update(&temp_header_bytes[74..120]);
         // Hash header padding (120 bytes to 256 KiB)
         let header_padding = vec![0u8; ALIGNMENT - HEADER_SIZE];

--- a/crates/lvl/src/prealloc.rs
+++ b/crates/lvl/src/prealloc.rs
@@ -11,9 +11,14 @@ pub async fn prealloc(input: &str, output: &str) {
 
     let mut reader = CircuitReaderV5a::open(input).unwrap();
     let header = reader.header();
-    let mut writer = WriterV5c::new(output, header.primary_inputs, header.num_outputs)
-        .await
-        .unwrap();
+    let mut writer = WriterV5c::new(
+        output,
+        header.primary_inputs,
+        header.num_outputs,
+        header.memo,
+    )
+    .await
+    .unwrap();
     let mut wire_map = WireMap::new();
 
     for _ in 0..header.primary_inputs + 2 {

--- a/util/adder/examples/roundtrip.rs
+++ b/util/adder/examples/roundtrip.rs
@@ -40,10 +40,16 @@ fn main() {
         // ===== WRITE PHASE =====
         println!("Writing circuit to {}...", temp_file.display());
 
-        let mut writer =
-            CircuitWriterV5a::new(&temp_file, circuit.primary_inputs, circuit.outputs.clone())
-                .await
-                .expect("Failed to create writer");
+        let memo = [1u8; 32];
+
+        let mut writer = CircuitWriterV5a::new(
+            &temp_file,
+            circuit.primary_inputs,
+            circuit.outputs.clone(),
+            memo,
+        )
+        .await
+        .expect("Failed to create writer");
 
         writer
             .write_gates(&circuit.gates)
@@ -94,6 +100,7 @@ fn main() {
             circuit.outputs.len() as u64,
             "Output count mismatch"
         );
+        assert_eq!(header.memo, memo);
         assert_eq!(
             header.xor_gates,
             circuit.num_xor_gates() as u64,
@@ -140,7 +147,7 @@ fn main() {
         println!("=== Roundtrip Test PASSED ===");
         println!();
         println!("The v5a format correctly preserves:");
-        println!("  • Circuit metadata (inputs, outputs, gate counts)");
+        println!("  • Circuit metadata (inputs, outputs, gate counts, memo)");
         println!("  • All output wire IDs");
         println!("  • All gate data (in1, in2, out, credits, type)");
         println!("  • Data integrity via BLAKE3 checksum");

--- a/util/adder/src/main.rs
+++ b/util/adder/src/main.rs
@@ -79,6 +79,7 @@ fn main() {
             &output_file,
             circuit.primary_inputs,
             circuit.outputs.clone(),
+            [0u8; 32],
         )
         .await
         .unwrap_or_else(|e| {


### PR DESCRIPTION
## Description

This PR adds a 32-byte memo to `v5a` and `v5c` headers. The memo is arbitrary and supplied by the user. The goal is to allow the user to include identifying data about the circuit, like an SP1 verification key.

It also updates how the `v5a` header is computed. Previously, fixed data (like magic bytes and version flags) was not included; now it is.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

The circuit header versions were not updated, and attempting to use this change with existing circuit files will lead to sadness.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes #104.