### PR TITLE
chore: bump format versions

### DIFF
--- a/crates/fmtv5-types/src/v5/SPEC.md
+++ b/crates/fmtv5-types/src/v5/SPEC.md
@@ -60,7 +60,7 @@ v5a is an intermediate format that preserves wire IDs and credits for memory man
 struct HeaderV5a {
     // Identification (40 bytes)
     magic: [u8; 4],          // 4 bytes: "Zk2u" (0x5A6B3275)
-    version: u8,             // 1 byte: Always 0x05
+    version: u8,             // 1 byte: Always 0x06
     format_type: u8,         // 1 byte: Always 0x00 for v5a
     reserved: [u8; 2],       // 2 bytes: Reserved, must be 0x0000
     memo: [u8; 32],          // 32 bytes: Arbitrary memo data
@@ -213,7 +213,7 @@ let file = OpenOptions::new()
 
 ### Header Validation
 1. Magic bytes must equal "Zk2u" (0x5A6B3275)
-2. Version must equal 0x05
+2. Version must equal 0x06
 3. Format type must be 0x00 (v5a) or 0x02 (v5c)
 4. Reserved fields must be zero
 5. Gate counts must sum to valid total

--- a/crates/fmtv5-types/src/v5/a/mod.rs
+++ b/crates/fmtv5-types/src/v5/a/mod.rs
@@ -33,7 +33,7 @@ pub const CREDITS_CONSTANT: u32 = MAX_CREDITS; // Wire is constant/primary input
 // v5a header constants (fixed by spec)
 pub const HEADER_SIZE_V5A: usize = 104;
 pub const MAGIC: [u8; 4] = *b"Zk2u";
-pub const VERSION: u8 = 0x05;
+pub const VERSION: u8 = 0x06;
 pub const FORMAT_TYPE_A: u8 = 0x00;
 
 // SoA block segment sizes (fixed by spec)

--- a/crates/fmtv5-types/src/v5/a/mod.rs
+++ b/crates/fmtv5-types/src/v5/a/mod.rs
@@ -58,7 +58,7 @@ pub struct GateV5a {
 #[derive(Debug, Clone, Copy)]
 pub struct HeaderV5a {
     pub magic: [u8; 4],      // "Zk2u"
-    pub version: u8,         // 0x05
+    pub version: u8,         // 0x06
     pub format_type: u8,     // 0x00 for v5a
     pub reserved: [u8; 2],   // 0x0000
     pub memo: [u8; 32],      // arbitrary memo data

--- a/crates/fmtv5-types/src/v5/a/reader.rs
+++ b/crates/fmtv5-types/src/v5/a/reader.rs
@@ -579,8 +579,8 @@ mod tests {
         let mut r = CircuitReaderV5a::open(&path).unwrap();
         let h = r.header();
 
-        assert_eq!(h.version, 0x05);
-        assert_eq!(h.format_type, 0x00);
+        assert_eq!(h.version, crate::v5::a::VERSION);
+        assert_eq!(h.format_type, crate::v5::a::FORMAT_TYPE_A);
         assert_eq!(h.primary_inputs, primary_inputs);
         assert_eq!(h.num_outputs, outputs.len() as u64);
         assert_eq!(h.memo, memo);

--- a/crates/fmtv5-types/src/v5/a/writer.rs
+++ b/crates/fmtv5-types/src/v5/a/writer.rs
@@ -699,12 +699,14 @@ mod tests {
 
     // Reference checksum verifier for tests (pure std I/O).
     fn verify_file_checksum(path: &Path) -> Result<bool> {
+        use crate::v5::a::{FORMAT_TYPE_A, MAGIC, VERSION};
+
         let mut f = StdOpen::new().read(true).open(path)?;
 
         // Read header
         let mut header = [0u8; HEADER_SIZE_V5A];
         f.read_exact(&mut header)?;
-        if &header[0..4] != b"Zk2u" || header[4] != 0x05 || header[5] != 0x00 {
+        if header[0..4] != MAGIC || header[4] != VERSION || header[5] != FORMAT_TYPE_A {
             return Err(Error::new(ErrorKind::InvalidData, "invalid header"));
         }
         let file_checksum = &header[40..72];

--- a/crates/fmtv5-types/src/v5/c/SPEC.md
+++ b/crates/fmtv5-types/src/v5/c/SPEC.md
@@ -74,7 +74,7 @@ All major sections are aligned to 256 KiB boundaries for optimal mmap and io_uri
 struct HeaderV5c {
     // Identification (10 bytes)
     magic: [u8; 4],          // 4 bytes: "Zk2u" (0x5A6B3275)
-    version: u8,             // 1 byte: Always 0x05
+    version: u8,             // 1 byte: Always 0x06
     format_type: u8,         // 1 byte: Always 0x02 for v5c
     nkas: [u8; 4],           // 4 bytes: "nkas" (0x6E6B6173)
     memo: [u8; 32],          // 32 bytes: arbitrary memo data
@@ -97,7 +97,7 @@ struct HeaderV5c {
 ### Header Fields
 
 - **magic**: Must be `[0x5A, 0x6B, 0x32, 0x75]` ("Zk2u")
-- **version**: Must be `0x05`
+- **version**: Must be `0x06`
 - **format_type**: Must be `0x02` (identifies v5c variant)
 - **nkas**: Must be `[0x6E, 0x6B, 0x61, 0x73]` ("nkas")
 - **memo**: Arbitrary
@@ -389,7 +389,7 @@ total_size = header_padded + outputs_padded + blocks_size
 ### Header Validation
 
 1. **Magic bytes**: Must equal `[0x5A, 0x6B, 0x32, 0x75]`
-2. **Version**: Must equal `0x05`
+2. **Version**: Must equal `0x06`
 3. **Format type**: Must equal `0x02`
 4. **nkas field**: Must equal `[0x6E, 0x6B, 0x61, 0x73]`
 5. **Reserved fields**: Must be zero

--- a/crates/fmtv5-types/src/v5/c/header.rs
+++ b/crates/fmtv5-types/src/v5/c/header.rs
@@ -9,7 +9,7 @@ use super::constants::*;
 pub struct HeaderV5c {
     // Identification (42 bytes)
     pub magic: [u8; 4],  // "Zk2u" (0x5A6B3275)
-    pub version: u8,     // Always 0x05
+    pub version: u8,     // Always 0x06
     pub format_type: u8, // Always 0x02 for v5c
     pub nkas: [u8; 4],   // "nkas" (0x6E6B6173)
     pub memo: [u8; 32],  // Arbitrary memo data

--- a/crates/fmtv5-types/src/v5/c/writer.rs
+++ b/crates/fmtv5-types/src/v5/c/writer.rs
@@ -400,9 +400,9 @@ mod tests {
         assert_eq!(bytes.len(), expected_size);
 
         // Verify header magic
-        assert_eq!(&bytes[0..4], b"Zk2u");
-        assert_eq!(bytes[4], 0x05); // version
-        assert_eq!(bytes[5], 0x02); // format_type v5c
+        assert_eq!(&bytes[0..4], crate::v5::c::MAGIC);
+        assert_eq!(bytes[4], crate::v5::c::VERSION); // version
+        assert_eq!(bytes[5], crate::v5::c::FORMAT_TYPE); // format_type v5c
     }
 
     #[monoio::test]

--- a/crates/fmtv5-types/src/v5/mod.rs
+++ b/crates/fmtv5-types/src/v5/mod.rs
@@ -18,8 +18,8 @@ mod avx512;
 /// Magic bytes for v5 format: "Zk2u" in ASCII
 pub const MAGIC: [u8; 4] = [0x5A, 0x6B, 0x32, 0x75];
 
-/// Version number for v5 format
-pub const VERSION: u8 = 0x05;
+/// Version number for v5c format
+pub const VERSION: u8 = 0x06;
 
 /// Format type identifiers
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Description

Since #105 changed the header format for both `v5a` and `v5c` for data embedding, we should change the format version numbers. This will provide better failure information.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

N/A

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Follows up on #105. Closes #110.
